### PR TITLE
Add LSB tags to init scrips + delete trailing spaces.

### DIFF
--- a/files/tomcat-initscript.sh
+++ b/files/tomcat-initscript.sh
@@ -3,6 +3,16 @@
 # chkconfig: 345 99 28
 # description: Starts/Stops Apache Tomcat
 #
+### BEGIN INIT INFO
+# Provides: tomcat
+# Required-Start: $network $syslog
+# Required-Stop: $network $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Description: Release implementation for Servlet 2.5 and JSP 2.1
+# Short-Description: start and stop tomcat
+### END INIT INFO
+#
 # Tomcat 7 start/stop/status script
 # Forked from: https://gist.github.com/valotas/1000094
 # @author: Miglen Evlogiev <bash@miglen.com>
@@ -13,32 +23,32 @@
 # Added coloring and additional status
 # Added check for existence of the tomcat user
 #
- 
+
 #Location of JAVA_HOME (bin files)
 export JAVA_HOME=/usr/lib/jvm/java-8-oracle/
- 
+
 #Add Java binary files to PATH
 export PATH=$JAVA_HOME/bin:$PATH
- 
-#CATALINA_HOME is the location of the bin files of Tomcat  
-export CATALINA_HOME=/usr/share/tomcat  
- 
+
+#CATALINA_HOME is the location of the bin files of Tomcat
+export CATALINA_HOME=/usr/share/tomcat
+
 #CATALINA_BASE is the location of the configuration files of this instance of Tomcat
 export CATALINA_BASE=/usr/share/tomcat
- 
+
 #TOMCAT_USER is the default user of tomcat
 export TOMCAT_USER=tomcat
- 
+
 #TOMCAT_USAGE is the message if this script is called without any options
 TOMCAT_USAGE="Usage: $0 {\e[00;32mstart\e[00m|\e[00;31mstop\e[00m|\e[00;32mstatus\e[00m|\e[00;31mrestart\e[00m}"
- 
+
 #SHUTDOWN_WAIT is wait time in seconds for java proccess to stop
 SHUTDOWN_WAIT=20
- 
+
 tomcat_pid() {
         echo `ps -fe | grep $CATALINA_BASE | grep -v grep | tr -s " "|cut -d" " -f2`
 }
- 
+
 start() {
   pid=$(tomcat_pid)
   if [ -n "$pid" ]
@@ -60,14 +70,14 @@ start() {
   fi
   return 0
 }
- 
+
 status(){
           pid=$(tomcat_pid)
           if [ -n "$pid" ]; then echo -e "\e[00;32mTomcat is running with pid: $pid\e[00m"
           else echo -e "\e[00;31mTomcat is not running\e[00m"
           fi
 }
- 
+
 stop() {
   pid=$(tomcat_pid)
   if [ -n "$pid" ]
@@ -75,7 +85,7 @@ stop() {
     echo -e "\e[00;31mStoping Tomcat\e[00m"
     #/bin/su -p -s /bin/sh tomcat
         sh $CATALINA_HOME/bin/shutdown.sh
- 
+
     let kwait=$SHUTDOWN_WAIT
     count=0;
     until [ `ps -p $pid | grep -c $pid` = '0' ] || [ $count -gt $kwait ]
@@ -84,7 +94,7 @@ stop() {
       sleep 1
       let count=$count+1;
     done
- 
+
     if [ $count -gt $kwait ]; then
       echo -n -e "\n\e[00;31mkilling processes which didn't stop after $SHUTDOWN_WAIT seconds\e[00m"
       kill -9 $pid
@@ -92,10 +102,10 @@ stop() {
   else
     echo -e "\e[00;31mTomcat is not running\e[00m"
   fi
- 
+
   return 0
 }
- 
+
 user_exists(){
         if id -u $1 >/dev/null 2>&1; then
         echo "1"
@@ -103,29 +113,29 @@ user_exists(){
                 echo "0"
         fi
 }
- 
+
 case $1 in
- 
+
         start)
           start
         ;;
-       
-        stop)  
+
+        stop)
           stop
         ;;
-       
+
         restart)
           stop
           start
         ;;
-       
+
         status)
                 status
-               
+
         ;;
-       
+
         *)
                 echo -e $TOMCAT_USAGE
         ;;
-esac    
+esac
 exit 0


### PR DESCRIPTION
Added LSB tags to init scrips + deleted trailing spaces.

Without LSB tags run fails on systemd systems, like Ubuntu 16.04, with errors:

> TASK [ragingbal.tomcat : Start Tomcat] *****************************************
fatal: [selectel]: FAILED! => {"changed": false, "failed": true, "msg": "Unable to enable service tomcat: tomcat.service is not a native service, redirecting to systemd-sysv-install\nExecuting /lib/systemd/systemd-sysv-install enable tomcat\ninsserv: warning: script 'tomcat' missing LSB tags and overrides\ninsserv: There is a loop between service watchdog and tomcat if stopped\ninsserv:  loop involving service tomcat at depth 2\ninsserv:  loop involving service watchdog at depth 1\ninsserv: Stopping tomcat depends on watchdog and therefore on system facility `$all' which can not be true!\ninsserv: exiting now without changing boot order!\nupdate-rc.d: error: insserv rejected the script header\n"}